### PR TITLE
Remove aggregator api disabling

### DIFF
--- a/dutch-auction/move/sources/dutch_auction.move
+++ b/dutch-auction/move/sources/dutch_auction.move
@@ -208,12 +208,7 @@ module dutch_auction_address::dutch_auction {
         owner: &signer,
         customer: &signer
     ) acquires Auction, TokenConfig {
-        use std::features;
-
         init_module(owner);
-
-        let feature = features::get_aggregator_v2_api_feature();
-        features::change_feature_flags(aptos_framework, vector[], vector[feature]);
 
         timestamp::set_time_has_started_for_testing(aptos_framework);
         timestamp::update_global_time_for_test_secs(1000);


### PR DESCRIPTION
If you keep disabling Aggregator API in dutch auction example, you will receive an error:

```
┌── test_auction_happy_path ──────
│ error[E11001]: test failure
│     ┌─ /Users/bshn/.move/https___github_com_aptos-labs_aptos-core_git_mainnet/aptos-move/framework/aptos-token-objects/sources/collection.move:373:13
│     │
│ 340 │     public(friend) fun increment_supply(
│     │                        ---------------- In this function in 0x4::collection
│     ·
│ 373 │             abort error::invalid_argument(ECONCURRENT_NOT_ENABLED)
│     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it aborted with code 65543 originating in the module 0000000000000000000000000000000000000000000000000000000000000004::collection rooted here
│ 
│ 
```

To fix this — I removed the code which disables it.